### PR TITLE
Switch from assertify to assert2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ serde_json = "1.0"
 phf = { version = "0", features = ["macros"] }
 
 [dev-dependencies]
-assertify = "0"
+assert2 = "0.3.7"

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -51,7 +51,6 @@ pub fn escape_all_quotes<S: AsRef<[u8]>>(raw: S) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assertify::testify;
 
     const BASIC_CORPUS: [(&str, &str); 4] = [
         ("", ""),
@@ -64,17 +63,17 @@ mod tests {
     test_multiple!(escape_attribute_basic, escape_attribute, BASIC_CORPUS);
     test_multiple!(escape_all_quotes_basic, escape_all_quotes, BASIC_CORPUS);
 
-    testify!(
+    test!(
         escape_text_quotes,
         escape_text("He said, \"That's mine.\"") == "He said, \"That's mine.\""
     );
 
-    testify!(
+    test!(
         escape_attribute_quotes,
         escape_attribute("He said, \"That's mine.\"") == "He said, &quot;That's mine.&quot;"
     );
 
-    testify!(
+    test!(
         escape_all_quotes_quotes,
         escape_all_quotes("He said, \"That's mine.\"") == "He said, &quot;That&apos;s mine.&quot;"
     );
@@ -83,11 +82,11 @@ mod tests {
     const HTML_DIRTY_ESCAPED: &str = include_str!("../tests/corpus/html-escaped.txt");
     const HTML_CLEAN: &str = include_str!("../tests/corpus/html-cleaned.txt");
 
-    testify!(
+    test!(
         escape_text_dirty_html,
         escape_text(HTML_DIRTY) == HTML_DIRTY_ESCAPED
     );
-    testify!(
+    test!(
         escape_text_clean_html,
         escape_text(HTML_CLEAN) == HTML_CLEAN
     );

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -5,8 +5,19 @@ macro_rules! test_multiple {
         #[test]
         fn $name() {
             for (input, expected) in &$tests {
-                ::assertify::assertify!($func(&input) == *expected);
+                ::assert2::assert!($func(&input) == *expected);
             }
+        }
+    };
+}
+
+#[cfg(test)]
+#[macro_export]
+macro_rules! test {
+    ($name:ident, $($test:tt)+) => {
+        #[test]
+        fn $name() {
+            ::assert2::assert!($($test)+);
         }
     };
 }

--- a/src/unescape.rs
+++ b/src/unescape.rs
@@ -305,52 +305,51 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assertify::testify;
 
-    testify!(almost_entity, unescape("&time") == "&time");
-    testify!(exact_no_semicolon, unescape("&times") == "×");
-    testify!(exact, unescape("&times;") == "×");
-    testify!(entity_char, unescape("&timesa") == "×a");
-    testify!(entity_char_is_prefix, unescape("&timesb") == "×b");
-    testify!(exact_timesb, unescape("&timesb;") == "⊠");
+    test!(almost_entity, unescape("&time") == "&time");
+    test!(exact_no_semicolon, unescape("&times") == "×");
+    test!(exact, unescape("&times;") == "×");
+    test!(entity_char, unescape("&timesa") == "×a");
+    test!(entity_char_is_prefix, unescape("&timesb") == "×b");
+    test!(exact_timesb, unescape("&timesb;") == "⊠");
 
-    testify!(no_entities, unescape("none") == "none");
-    testify!(only_ampersand, unescape("&") == "&");
-    testify!(empty_entity, unescape("&;") == "&;");
-    testify!(middle_entity, unescape(" &amp; ") == " & ");
-    testify!(extra_ampersands, unescape("&&amp;&") == "&&&");
-    testify!(two_entities, unescape("AND &amp;&AMP; and") == "AND && and");
-    testify!(
+    test!(no_entities, unescape("none") == "none");
+    test!(only_ampersand, unescape("&") == "&");
+    test!(empty_entity, unescape("&;") == "&;");
+    test!(middle_entity, unescape(" &amp; ") == " & ");
+    test!(extra_ampersands, unescape("&&amp;&") == "&&&");
+    test!(two_entities, unescape("AND &amp;&AMP; and") == "AND && and");
+    test!(
         long_entity,
         unescape("&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;")
             == "&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;"
     );
 
-    testify!(correct_hex_lowerx_lower, unescape("&#x7a;") == "z");
-    testify!(correct_hex_lowerx_upper, unescape("&#x7A;") == "z");
-    testify!(correct_hex_upperx_lower, unescape("&#X7a;") == "z");
-    testify!(correct_hex_upperx_upper, unescape("&#X7A;") == "z");
-    testify!(correct_dec, unescape("&#122;") == "z");
-    testify!(correct_hex_unicode, unescape("&#x21D2;") == "⇒");
+    test!(correct_hex_lowerx_lower, unescape("&#x7a;") == "z");
+    test!(correct_hex_lowerx_upper, unescape("&#x7A;") == "z");
+    test!(correct_hex_upperx_lower, unescape("&#X7a;") == "z");
+    test!(correct_hex_upperx_upper, unescape("&#X7A;") == "z");
+    test!(correct_dec, unescape("&#122;") == "z");
+    test!(correct_hex_unicode, unescape("&#x21D2;") == "⇒");
 
-    testify!(hex_no_semicolon, unescape("&#x7Az") == "zz");
-    testify!(hex_no_semicolon_end, unescape("&#x7A") == "z");
-    testify!(dec_no_semicolon, unescape("&#122z") == "zz");
-    testify!(dec_no_semicolon_end, unescape("&#122") == "z");
+    test!(hex_no_semicolon, unescape("&#x7Az") == "zz");
+    test!(hex_no_semicolon_end, unescape("&#x7A") == "z");
+    test!(dec_no_semicolon, unescape("&#122z") == "zz");
+    test!(dec_no_semicolon_end, unescape("&#122") == "z");
 
-    testify!(hex_instead_of_dec, unescape("&#7a;") == "&#7a;");
-    testify!(invalid_hex_lowerx, unescape("&#xZ;") == "&#xZ;");
-    testify!(invalid_hex_upperx, unescape("&#XZ;") == "&#XZ;");
+    test!(hex_instead_of_dec, unescape("&#7a;") == "&#7a;");
+    test!(invalid_hex_lowerx, unescape("&#xZ;") == "&#xZ;");
+    test!(invalid_hex_upperx, unescape("&#XZ;") == "&#XZ;");
 
-    testify!(special_entity_null, unescape("&#0;") == "\u{fffd}");
-    testify!(special_entity_bullet, unescape("&#x95;") == "•");
-    testify!(
+    test!(special_entity_null, unescape("&#0;") == "\u{fffd}");
+    test!(special_entity_bullet, unescape("&#x95;") == "•");
+    test!(
         special_entity_bullets,
         unescape("&#x95;&#149;&#x2022;•") == "••••"
     );
-    testify!(special_entity_space, unescape("&#x20") == " ");
+    test!(special_entity_space, unescape("&#x20") == " ");
 
     const ALL_SOURCE: &str = include_str!("../tests/corpus/all-entities-source.txt");
     const ALL_EXPANDED: &str = include_str!("../tests/corpus/all-entities-expanded.txt");
-    testify!(all_entities, unescape(ALL_SOURCE) == ALL_EXPANDED);
+    test!(all_entities, unescape(ALL_SOURCE) == ALL_EXPANDED);
 }


### PR DESCRIPTION
The assert2 crate is generally more useful than my assertify crate, except that it doesn’t have the equivalent of `testify!`. In preparation for deprecating assertify, this switches to assert2.