### PR TITLE
misc 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change log
+
+All notable changes to this project will be documented in this file.
+
+## Release 0.5.1 (2022-12-13)
+
+### Bugfixes
+
+* Switched from [assertify][] (deprecated) to [assert2][] for testing.
+* Fixed typo of in docs: “entries.json” should have been “entities.json”.
+* Fixed formatting and lints.
+* Added this change log.
+
+[assertify]: https://crates.io/crates/assertify
+[assert2]: https://crates.io/crates/assert2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ categories = ["web-programming", "encoding"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [build-dependencies]
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htmlize"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Daniel Parks <oss-htmlize@demonhorse.org>"]
 description = "Encode and decode HTML entities in UTF-8"
 homepage = "https://github.com/danielparks/htmlize"


### PR DESCRIPTION
- Remove maintenance badge from Cargo.toml
- ~~Specify phf version that was current when I wrote the code.~~ (I‘m satisfied that any version <1 is fine)
- 0.5.1: Add change log and switch to assert2.
