### PR TITLE
Basic release tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+# Mostly copied from https://github.com/taiki-e/cargo-hack/blob/72a9fc95377c453a18026329577c59fa60bfa737/.github/workflows/release.yml
+name: Release
+
+permissions:
+  # TODO: once `releases: write` is supported, use it instead.
+  contents: write
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+
+defaults:
+  run:
+    # Setting shell: bash explicitly activates pipefail
+    shell: bash
+
+jobs:
+  create-release:
+    if: github.repository_owner == 'danielparks'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: rustup update stable --no-self-update
+      - run: cargo package
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          changelog: CHANGELOG.md
+          title: Release $version
+          branch: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -eo pipefail
+shopt -s extglob
+
+version=$1
+
+awk-in-place () {
+  local tmpfile=$(mktemp)
+  local original="$1"
+  shift
+  cp "$original" "$tmpfile"
+  awk "$@" <"$tmpfile" >"$original"
+  rm "$tmpfile"
+}
+
+confirm () {
+  local prompt="$1"
+  local answer
+  read -n 1 -p "${prompt} [yN] " answer
+  case $answer in
+    [yY]*) echo ;; # Continue
+    *) echo ; echo Canceling. >&2 ; exit 1 ;;
+  esac
+}
+
+case $version in
+  +([0-9]).+([0-9]).+([0-9])) ;; # Good
+  *) echo "Usage $0 VERSION" >&2 ; exit 1 ;;
+esac
+
+echo 'Making sure version is correct.'
+
+awk-in-place Cargo.toml '
+  /^version *=/ && !done {
+    sub(/"[0-9.]+"/, "\"'$version'\"")
+    done=1
+  }
+  { print }'
+
+sed -i '' -e 's/^version *= *".*"/version = "'$version'"/' Cargo.toml
+cargo check --quiet
+
+awk-in-place CHANGELOG.md '
+  /^## / && !done {
+    $0 = "## Release '$version' ('$(date +%Y-%m-%d)')"
+    done=1
+  }
+  { print }'
+
+# Check for changes
+if git ls-files --exclude-standard --other | grep . >/dev/null ; then
+  echo 'Found untracked files:' >&2
+  git ls-files --exclude-standard --other | sed -e 's/^/  /' >&2
+  echo >&2
+  echo 'Please commit changes before proceeding.' >&2
+  exit 1
+fi
+
+git diff --color --exit-code HEAD || {
+  echo >&2
+  echo 'Please commit changes before proceeding.' >&2
+  exit 1
+}
+
+# Confirm changelog
+changelog=$(mktemp)
+{
+  echo "## Release ${version}"
+  echo
+  parse-changelog CHANGELOG.md "$version"
+} >"$changelog"
+
+cat "$changelog"
+echo
+confirm 'Release notes displayed above. Continue?'
+
+git tag --sign --file "$changelog" --cleanup=verbatim "v${version}"
+git push --tags origin main
+
+awk-in-place CHANGELOG.md '
+  /^## Release/ && !done {
+    print "## main branch\n"
+    done=1
+  }
+  { print }'
+
+git add CHANGELOG.md
+git diff --staged
+
+confirm 'Commit with message "Prepping CHANGELOG.md for development."?'
+
+git commit -m 'Prepping CHANGELOG.md for development.'


### PR DESCRIPTION
Adds:

  * `release.sh` manage version, manage `CHANGELOG.md`, and update version.
  * Release workflow for GitHub actions to create a GitHub release and publish to crates.io.

Mostly just copied wholesale from [git-status-vars][].

This also adds a `dependabot.yml` file to configure Dependabot to check for updates to GitHub actions monthly.

[git-status-vars]: https://github.com/danielparks/git-status-vars