### PR TITLE
Use my standard fmt settings (80 character lines)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,8 +33,8 @@ fn main() {
 
     w!("/// A map of all valid HTML entities to their expansions.");
     w!("///");
-    w!(r#"/// The keys of the map are full entity byte strings, e.g. `b"&copy;"`, and the"#);
-    w!(r#"/// values are their expansions, e.g. `b"©"`."#);
+    w!("/// The keys of the map are full entity byte strings, e.g. `b\"&copy;\"`, and the");
+    w!("/// values are their expansions, e.g. `b\"©\"`.");
     w!("///");
     w!("/// See the [WHATWG HTML spec][spec] for the canonical list of entities with");
     w!("/// their codepoints and glyphs. The [entities.json][] file linked there is");
@@ -94,7 +94,7 @@ pub fn load_entities<P: AsRef<Path>>(path: P) -> Vec<(String, String)> {
 
     let mut entities = Vec::new();
     for (name, info) in input {
-        entities.push((name, String::from(info["characters"].as_str().unwrap())))
+        entities.push((name, info["characters"].as_str().unwrap().to_owned()))
     }
 
     entities

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 80
+newline_style = "Unix"

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -70,16 +70,19 @@ mod tests {
 
     test!(
         escape_attribute_quotes,
-        escape_attribute("He said, \"That's mine.\"") == "He said, &quot;That's mine.&quot;"
+        escape_attribute("He said, \"That's mine.\"")
+            == "He said, &quot;That's mine.&quot;"
     );
 
     test!(
         escape_all_quotes_quotes,
-        escape_all_quotes("He said, \"That's mine.\"") == "He said, &quot;That&apos;s mine.&quot;"
+        escape_all_quotes("He said, \"That's mine.\"")
+            == "He said, &quot;That&apos;s mine.&quot;"
     );
 
     const HTML_DIRTY: &str = include_str!("../tests/corpus/html-raw.txt");
-    const HTML_DIRTY_ESCAPED: &str = include_str!("../tests/corpus/html-escaped.txt");
+    const HTML_DIRTY_ESCAPED: &str =
+        include_str!("../tests/corpus/html-escaped.txt");
     const HTML_CLEAN: &str = include_str!("../tests/corpus/html-cleaned.txt");
 
     test!(

--- a/src/unescape.rs
+++ b/src/unescape.rs
@@ -286,7 +286,9 @@ where
     for check_len in (ENTITY_MIN_LENGTH..=max_len).rev() {
         if let Some(expansion) = ENTITIES.get(&candidate[..check_len]) {
             // Found a match.
-            let mut result = Vec::with_capacity(expansion.len() + candidate.len() - check_len);
+            let mut result = Vec::with_capacity(
+                expansion.len() + candidate.len() - check_len,
+            );
             result.extend_from_slice(expansion);
 
             if check_len < candidate.len() {
@@ -349,7 +351,9 @@ mod tests {
     );
     test!(special_entity_space, unescape("&#x20") == " ");
 
-    const ALL_SOURCE: &str = include_str!("../tests/corpus/all-entities-source.txt");
-    const ALL_EXPANDED: &str = include_str!("../tests/corpus/all-entities-expanded.txt");
+    const ALL_SOURCE: &str =
+        include_str!("../tests/corpus/all-entities-source.txt");
+    const ALL_EXPANDED: &str =
+        include_str!("../tests/corpus/all-entities-expanded.txt");
     test!(all_entities, unescape(ALL_SOURCE) == ALL_EXPANDED);
 }


### PR DESCRIPTION
For some reason `cargo fmt` likes to change this:

```rust
w!(r#"Long line with quotes: "...more than 80 characters..."#);
```

into this:

```rust
w!(
    r#"Long line with quotes: "...more than 80 characters..."#
);
```

So I made a few changes.