### PR TITLE
Pre-allocate output buffer for `unescape()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 
 * Switched to the [phf_codegen][] crate instead of using the `phf_map!` macro.
   On my machine, this cuts build time by about 25% (~2 seconds).
+* Pre-allocated the output buffer for `unescape()`, which generally improves
+  performance slightly.
 * Clarified documentation of `ENTITIES` to indicate that it’s a `Map`, not just
   a collection of tuples.
 

--- a/src/unescape.rs
+++ b/src/unescape.rs
@@ -23,7 +23,11 @@ include!(concat!(env!("OUT_DIR"), "/entities.rs"));
 pub fn unescape<S: AsRef<[u8]>>(escaped: S) -> String {
     let escaped = escaped.as_ref();
     let mut iter = escaped.iter().peekable();
-    let mut buffer = Vec::new(); // FIXME Vec::with_capacity(escaped.len())? Shrink on return?
+
+    // Most (all?) entities are longer than their expansion, so allocating the
+    // output buffer to be the same size as the input will usually prevent
+    // multiple allocations and generally won’t over-allocate by very much.
+    let mut buffer = Vec::with_capacity(escaped.len());
 
     while let Some(c) = iter.next() {
         if *c == b'&' {


### PR DESCRIPTION
The output of `unescape()` will almost always be slightly shorter than the input, since HTML entities are mostly (all?) longer than their UTF-8 expansion. We can take advantage of this to pre-allocate the output buffer so that it doesn’t have to repeatedly expand as we write to it.