### PR TITLE
escape: pre-allocate twice input space for output

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -13,7 +13,7 @@ fn map_u8(c: u8) -> &'static [u8] {
 macro_rules! escape {
     ($raw:expr, $($ch:literal),+) => {{
         let raw = $raw.as_ref();
-        let mut output: Vec<u8> = Vec::with_capacity(raw.len());
+        let mut output: Vec<u8> = Vec::with_capacity(raw.len() * 2);
 
         for c in raw {
             match c {


### PR DESCRIPTION
`Vec` currently doubles its allocation whenever it needs more space, so this is just assuming that the output will be longer than the input (true in every case where at least one character needs to be escaped) and skipping the first allocation.

### escape/escape_text/small_dirty

                        time:   [116.25 ns 116.80 ns 117.45 ns]
                        thrpt:  [381.65 MiB/s 383.75 MiB/s 385.58 MiB/s]
                 change:
                        time:   [-40.960% -40.224% -39.423%] (p = 0.00 < 0.01)
                        thrpt:  [+65.078% +67.292% +69.377%]
                        Performance has improved.

### escape/escape_text/big_dirty

                        time:   [671.27 ns 674.45 ns 677.78 ns]
                        thrpt:  [434.78 MiB/s 436.93 MiB/s 439.00 MiB/s]
                 change:
                        time:   [-14.166% -13.054% -11.942%] (p = 0.00 < 0.01)
                        thrpt:  [+13.561% +15.014% +16.504%]
                        Performance has improved.

### escape/escape_text/small_clean

                        time:   [114.17 ns 114.88 ns 115.60 ns]
                        thrpt:  [387.72 MiB/s 390.17 MiB/s 392.60 MiB/s]
                 change:
                        time:   [-7.9045% -6.5370% -5.1956%] (p = 0.00 < 0.01)
                        thrpt:  [+5.4803% +6.9943% +8.5829%]
                        Change within noise threshold.

### escape/escape_text/big_clean

                        time:   [510.15 ns 512.80 ns 515.58 ns]
                        thrpt:  [571.56 MiB/s 574.66 MiB/s 577.64 MiB/s]
                 change:
                        time:   [-5.9921% -4.8087% -3.6133%] (p = 0.00 < 0.01)
                        thrpt:  [+3.7487% +5.0517% +6.3740%]
                        Change within noise threshold.