### PR TITLE
First pass at cycle counting with iai

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 [features]
 default = []
 unescape = ["serde_json", "phf", "phf_codegen"]
+iai = []
 
 [build-dependencies]
 phf = { version = "0.11.1", default-features = false, optional = true }
@@ -26,14 +27,25 @@ phf = { version = "0.11.1", default-features = false, optional = true }
 [dev-dependencies]
 assert2 = "0.3.7"
 criterion = "0.4.0"
+iai = "0.1.1"
 paste = "1.0.11"
 
 [lib]
 bench = false
 
 [[bench]]
+name = "escape_iai"
+harness = false
+required-features = ["iai"]
+
+[[bench]]
 name = "escape"
 harness = false
+
+[[bench]]
+name = "unescape_iai"
+harness = false
+required-features = ["unescape", "iai"]
 
 [[bench]]
 name = "unescape"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Docker image for running `cargo bench --features iai iai`. Use docker.sh to
+# build and run.
+
+FROM ubuntu:latest
+
+RUN apt-get update \
+  && apt-get install -y locales curl valgrind build-essential \
+  && rm -rf /var/lib/apt/lists/* \
+	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+  | sh -s -- -y --default-toolchain stable
+
+ENV PATH=/root/.cargo/bin:$PATH
+
+# Install cargo-binstall
+RUN curl -sSfL https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz \
+  | tar -C /root/.cargo/bin/ -xzf -
+
+COPY . /work
+WORKDIR /work
+RUN cargo build --benches --all-features

--- a/README.md
+++ b/README.md
@@ -80,6 +80,42 @@ documentation][`unescape_in()`] for more information.
 
   * `unescape`: build `ENTITIES` map and provide `unescape()` function. Enabling
     this will add a dependency on [phf] and may slow builds by a few seconds.
+  * `iai`: enable [iai] benchmarks. This should only be used when running
+    benchmarks. See the [Benchmarks](#benchmarks) section below.
+
+## Benchmarks
+
+This has two suites of benchmarks. One is a typical multi-run benchmark using
+[criterion]. These can be run with `cargo bench` or [`cargo criterion`] if you
+have it installed.
+
+The other suite of benchmarks uses [iai] to count instructions, cache accesses,
+and to estimate cycles. It requires the `iai` feature to be enabled, and only
+really works well on Linux.
+
+To run iai benchmarks locally:
+
+```sh
+cargo bench --features iai iai
+```
+
+You may want to use `--all-features` or `--features iai,unescape` to enable
+benchmarks of the `unescape()` function.
+
+To run in a Docker container, use the `docker.sh` script. It will build an image
+if necessary, then use that image for all future runs:
+
+```sh
+./docker.sh cargo bench --features iai iai
+```
+
+You can also start it in interactive mode and run the benchmark multiple times:
+
+```
+❯ ./docker.sh
+root@d0a0db46770d:/work# cargo bench --features iai iai
+   Compiling htmlize [...]
+```
 
 ## License
 
@@ -105,3 +141,6 @@ additional terms or conditions.
 [`unescape_in()`]: https://docs.rs/htmlize/0.5.1/htmlize/fn.unescape_in.html
 [official WHATWG algorithm]: https://html.spec.whatwg.org/multipage/parsing.html#character-reference-state
 [phf]: https://crates.io/crates/phf
+[iai]: https://crates.io/crates/iai
+[criterion]: https://crates.io/crates/criterion
+[`cargo criterion`]: https://crates.io/crates/cargo-criterion

--- a/benches/escape_iai.rs
+++ b/benches/escape_iai.rs
@@ -1,0 +1,28 @@
+use htmlize::*;
+use iai::black_box;
+use paste::paste;
+
+macro_rules! iai_benchmarks {
+    ( $( ($name:ident, $input:expr), )+ ) => {
+        paste! {
+            $(
+                fn [<iai_escape_text_ $name>]() -> String {
+                    escape_text(black_box($input))
+                }
+            )+
+
+            iai::main!(
+                $(
+                    [<iai_escape_text_ $name>],
+                )+
+            );
+        }
+    }
+}
+
+iai_benchmarks! {
+    (small_clean, ".a href=.http://example.com/..link./a. . [link]"),
+    (big_clean, include_str!("../tests/corpus/html-cleaned.txt")),
+    (small_dirty, "<a href=\"http://example.com/\">link</a> & [link]"),
+    (big_dirty, include_str!("../tests/corpus/html-raw.txt")),
+}

--- a/benches/unescape_iai.rs
+++ b/benches/unescape_iai.rs
@@ -1,0 +1,47 @@
+use htmlize::*;
+use iai::black_box;
+use paste::paste;
+
+macro_rules! iai_benchmarks {
+    ( $( ($name:ident, $input:expr), )+ ) => {
+        paste! {
+            $(
+                fn [<iai_unescape_ $name>]() -> String {
+                    unescape(black_box($input))
+                }
+
+                fn [<iai_unescape_attribute_ $name>]() -> String {
+                    unescape(black_box($input))
+                }
+            )+
+
+            iai::main!(
+                $(
+                    [<iai_unescape_ $name>],
+                    [<iai_unescape_attribute_ $name>],
+                )+
+            );
+        }
+    }
+}
+
+// FIXME: we’re benchmarking making the sample too.
+fn make_sample(count: usize, entity: &str, padding: &str) -> String {
+    let mut s = padding.repeat(count);
+    s.extend(entity.chars());
+    s.repeat(count)
+}
+
+iai_benchmarks! {
+    (none, "sdfasfdasfsdf"),
+    (single_prefix, "sdfasfdasfsdf&amp;"),
+    (long_invalid, "&abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+    (all_entities, include_str!("../tests/corpus/all-entities-source.txt")),
+    (html_document, include_str!("../tests/corpus/html-escaped.txt")),
+    (sample_32_bare, make_sample(32, "&lt", "a")),
+    (sample_32, make_sample(32, "&lt;", "a")),
+    (sample_64_bare, make_sample(64, "&lt", "a")),
+    (sample_64, make_sample(64, "&lt;", "a")),
+    (sample_128_bare, make_sample(128, "&lt", "a")),
+    (sample_128, make_sample(128, "&lt;", "a")),
+}

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Usage: ./docker.sh cargo bench --features iai iai
+# Interactive usage: ./docker.sh
+
+set -eo pipefail
+
+if [[ $# == 0 ]] ; then
+  command=(bash)
+else
+  command=("$@")
+fi
+
+image=dp-rust:0.3
+
+if ! docker inspect "$image" >/dev/null ; then
+  docker build -t "$image" .
+fi
+
+docker run -ti --rm --privileged -v $(pwd):/work -w /work "$image" "$@"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,12 +24,16 @@
 //! # Features
 //!
 //!   * `unescape`: build [`ENTITIES`] map and provide [`unescape()`]. Enabling
-//!     this will add a dependency on [phf][] and may slow builds by a few
+//!     this will add a dependency on [phf] and may slow builds by a few
 //!     seconds.
+//!   * `iai`: enable [iai] benchmarks. This should only be used when running
+//!     benchmarks. See the [Benchmarks section in the README][benchmarks].
 //!
 //! The `escape` functions are all available with no features enabled.
 //!
 //! [phf]: https://crates.io/crates/phf
+//! [iai]: https://crates.io/crates/iai
+//! [benchmarks]: https://github.com/danielparks/htmlize#benchmarks
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
[iai] “benchmarks” functions by counting instructions, cache hits, and memory accesses. It also estimates cycles.

It uses [`valgrind`], which officially doesn’t run on macOS (though there is a [port]), and `setarch`, a Linux-only command they use to disable address space layout randomization (ASLR). See [iai #25] for more information about running on macOS.

This includes a Dockerfile to provide an environment to run `valgrind`.

Note that iai hasn’t been updated since February 2021.

To do:

  * [x] Look for a maintained alternative.
  * [x] Write macros to remove duplication in benchmarks.
  * [x] Document how to run iai benchmarks.
  * [x] Add CI report from iai run?

[iai]: https://github.com/bheisler/iai
[`valgrind`]: https://valgrind.org
[port]: https://github.com/LouisBrunner/valgrind-macos
[iai #25]: https://github.com/bheisler/iai/issues/25