### PR TITLE
minor changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -52,7 +52,15 @@ fn generate_entities_rs() {
     w!("///");
     w!("/// Entity                         | Codepoints         | Glyph");
     w!("/// -------------------------------|--------------------|------");
+
+    let mut map_builder = phf_codegen::Map::<&[u8]>::new();
+    let mut max_len: usize = 0;
+    let mut min_len: usize = usize::max_value();
     for (name, glyph) in &entities {
+        map_builder.entry(name.as_bytes(), &format!("&{:?}", glyph.as_bytes()));
+        max_len = max(max_len, name.len());
+        min_len = min(min_len, name.len());
+
         let codepoints: Vec<String> = glyph
             .chars()
             .map(|c| format!("U+{:06X}", u32::from(c)))
@@ -69,15 +77,6 @@ fn generate_entities_rs() {
         };
 
         w!("/// {:30} | {:18} | {}", name, codepoints.join(", "), glyph);
-    }
-
-    let mut map_builder = phf_codegen::Map::<&[u8]>::new();
-    let mut max_len: usize = 0;
-    let mut min_len: usize = usize::max_value();
-    for (name, value) in &entities {
-        map_builder.entry(name.as_bytes(), &format!("&{:?}", value.as_bytes()));
-        max_len = max(max_len, name.len());
-        min_len = min(min_len, name.len());
     }
 
     w!(

--- a/src/unescape.rs
+++ b/src/unescape.rs
@@ -83,9 +83,13 @@ pub fn unescape_in<S: AsRef<[u8]>>(escaped: S, context: Context) -> String {
     let escaped = escaped.as_ref();
     let mut iter = escaped.iter().peekable();
 
-    // Most (all?) entities are longer than their expansion, so allocating the
-    // output buffer to be the same size as the input will usually prevent
-    // multiple allocations and generally won’t over-allocate by very much.
+    // All but two entities are as long or longer than their expansion, so
+    // allocating the output buffer to be the same size as the input will
+    // usually prevent multiple allocations and generally won’t over-allocate
+    // by very much.
+    //
+    // The two entities are `&nGg;` (≫⃒) and `&nLl;` (≪⃒) which are both five
+    // byte entities with six byte expansions.
     let mut buffer = Vec::with_capacity(escaped.len());
 
     while let Some(c) = iter.next() {


### PR DESCRIPTION
- unescape: order functions from outer to inner.
- build.rs: combine two loops.
- unescape: update comment about entity length
