### PR TITLE
Prevent GitHub from counting benchmark results toward code totals.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Prevent GitHub from counting benchmark results toward code totals
+target/** linguist-generated


### PR DESCRIPTION
This doesn’t seem to affect the language report widget on a branch. Maybe it needs to be merged?