### PR TITLE
Set minimum supported Rust version to 1.60

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -43,6 +43,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
 
+  msrv:
+    name: cargo msrv
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
+      # For some reason caching (?) saves the cargo-msrv symlink, but not the
+      # actual binary. Hence, --force.
+      - run: cargo binstall --force -y --pkg-url="{ repo }/releases/download/v{ version }/{ name }_v{ version }_Linux_x86_64{ archive-suffix }" --pkg-fmt="tar" cargo-msrv
+      - run: cargo msrv verify
+
   semver:
     name: cargo semver-checks
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 * Switched both escape and unescape functions to use `Cow<'a, str>` for input
   and output. This allows for significant performance improvements when the
   input can be returned unchanged (see performance improvements below for more).
+* Updated minimum supported Rust version (MSRV) to 1.60.
 
 ### Improvements
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,12 @@ readme = "README.md"
 keywords = ["html", "entities", "escape", "unescape", "encode", "decode"]
 categories = ["web-programming", "encoding"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.60"
 
 [features]
 default = []
-unescape = ["serde_json", "phf", "phf_codegen"]
+unescape = ["dep:serde_json", "dep:phf", "dep:phf_codegen"]
 iai = []
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![docs.rs](https://img.shields.io/docsrs/htmlize)][docs.rs]
 [![Crates.io](https://img.shields.io/crates/v/htmlize)][crates.io]
+![Rust version 1.60+](https://img.shields.io/badge/Rust%20version-1.60%2B-success)
 
 If you only need to escape text for embedding into HTML then installing is as
 simple as running:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,11 @@
 //!
 //! The `escape` functions are all available with no features enabled.
 //!
+//! # Minimum supported Rust version
+//!
+//! Currently the minimum supported Rust version (MSRV) is **1.60**. Future
+//! increases in the MSRV will require a major version bump.
+//!
 //! [phf]: https://crates.io/crates/phf
 //! [iai]: https://crates.io/crates/iai
 //! [benchmarks]: https://github.com/danielparks/htmlize#benchmarks


### PR DESCRIPTION
The crate already required 1.60; this just makes it official. This also updates to Rust 2021 since it’s supported by Rust 1.60.

This adds a CI check to verify that the MSRV stays the same.