### PR TITLE
Remove cargo semver-checks from CI

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -57,12 +57,3 @@ jobs:
       # actual binary. Hence, --force.
       - run: cargo binstall --force -y --pkg-url="{ repo }/releases/download/v{ version }/{ name }_v{ version }_Linux_x86_64{ archive-suffix }" --pkg-fmt="tar" cargo-msrv
       - run: cargo msrv verify
-
-  semver:
-    name: cargo semver-checks
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v1

--- a/release.sh
+++ b/release.sh
@@ -47,6 +47,8 @@ awk-in-place README.md '{
 
 cargo check --quiet
 
+cargo semver-checks check-release
+
 awk-in-place CHANGELOG.md '
   /^## / && !done {
     $0 = "## Release '$version' ('$(date +%Y-%m-%d)')"


### PR DESCRIPTION
It’s too slow. I may add it back when it gets faster.

This adds it to release.sh.