### PR TITLE
Add `unescape_bytes_in()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
   entities in the value of an HTML attribute. Also adds `unescape_in()`, which
   takes a context parameter that can either be `Context::Attribute` or
   `Context::General` (for everything else).
+* Added `unescape_bytes_in()` to work on `[u8]` rather than `str`.
 * Added `escape_..._bytes()` functions to work on `[u8]` rather than `str`.
 * Switched to the [phf_codegen][] crate instead of using the `phf_map!` macro.
   On my machine, this cuts build time by about 25% (~2 seconds).

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ This follows the [official WHATWG algorithm] for expanding entities based on
 the context where they are found. See the [reference
 documentation][`unescape_in()`] for more information.
 
+### `unescape_bytes_in([u8], Htmlize::Context) -> [u8]` ([reference][`unescape_bytes_in()`])
+
+This is the same as [`unescape_in()`], except that it works on bytes rather than
+strings. (Note that both functions actually take and return [`Cow`]s.)
+
 ## Features
 
   * `unescape`: build `ENTITIES` map and provide `unescape()` function. Enabling
@@ -140,6 +145,8 @@ additional terms or conditions.
 [`unescape()`]: https://docs.rs/htmlize/0.5.1/htmlize/fn.unescape.html
 [`unescape_attribute()`]: https://docs.rs/htmlize/0.5.1/htmlize/fn.unescape_attribute.html
 [`unescape_in()`]: https://docs.rs/htmlize/0.5.1/htmlize/fn.unescape_in.html
+[`unescape_bytes_in()`]: https://docs.rs/htmlize/0.5.1/htmlize/fn.unescape_bytes_in.html
+[`Cow`]: https://doc.rust-lang.org/std/borrow/enum.Cow.html
 [official WHATWG algorithm]: https://html.spec.whatwg.org/multipage/parsing.html#character-reference-state
 [phf]: https://crates.io/crates/phf
 [iai]: https://crates.io/crates/iai

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@
 //! parameter. See its documentation for a discussion of the differences between
 //! expanding attribute values and general text.
 //!
+//! [`unescape_bytes_in()`] is just like [`unescape_in()`] except that it works
+//! on `[u8]` rather than strings.
+//!
 //! # Features
 //!
 //!   * `unescape`: build [`ENTITIES`] map and provide [`unescape()`]. Enabling


### PR DESCRIPTION
This adds an decode function that works on bytes rather than strings, and factors out the common code into `unescape_in_internal()`.

Fixes: #42 — Add `unescape_bytes_in()`

---

Should I add `_bytes` versions of the other `unescape` functions?