### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@
 //! [iai]: https://crates.io/crates/iai
 //! [benchmarks]: https://github.com/danielparks/htmlize#benchmarks
 
+#![forbid(unsafe_code)]
+
 mod escape;
 pub use escape::*;
 


### PR DESCRIPTION
I tested using `std::str::from_utf8_unchecked()` at one point, and found that the performance benefit was within the noise of my benchmarks. I think it’s pretty safe to say that we can avoid unsafe code at least for the next major version.