### PR TITLE
Fix unescape feature without unescape_fast

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo build --tests
       - run: cargo test --all-features
+      - run: cargo test --features unescape
+      - run: cargo test --features entities
+      - run: cargo test
 
   fmt:
     name: cargo fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+* Fix building with `unescape` feature but not `unescape_fast`. Added tests for
+  a few common feature flags — in addition to `--all-features` — to the CI check
+  to avoid this sort of problem in the future.
+
 ## Release 1.0.1 (2023-03-04)
 
 * Fix [docs.rs] build to enable the `unescape` and `entities` features.

--- a/src/unescape.rs
+++ b/src/unescape.rs
@@ -277,6 +277,7 @@ unescape_fns!(_slow);
 // fn entity_matcher<'a, I>(iter: &mut I) -> Option<(bool, &'static [u8])>
 // where
 //     I: Iterator<Item = &'a u8> + Clone,
+#[cfg(feature = "unescape_fast")]
 include!(concat!(env!("OUT_DIR"), "/matcher.rs"));
 
 /// Match an entity at the beginning of `iter`. Either:


### PR DESCRIPTION
This fixes building with the `unescape` feature but without `unescape_fast`.  It adds tests for a few common feature flags — in addition to `--all-features` — to the CI check to avoid this sort of problem in the future.