### PR TITLE
Add tests for invalid UTF-8 support

### DIFF
--- a/src/escape.rs
+++ b/src/escape.rs
@@ -327,4 +327,17 @@ mod tests {
         escape_text_bytes_clean_html,
         escape_text_bytes(HTML_CLEAN.as_bytes()) == HTML_CLEAN.as_bytes()
     );
+
+    test!(
+        escape_text_bytes_invalid_utf8,
+        escape_text_bytes(&b"\xa1"[..]) == &b"\xa1"[..]
+    );
+    test!(
+        escape_attribute_bytes_invalid_utf8,
+        escape_attribute_bytes(&b"\xa1"[..]) == &b"\xa1"[..]
+    );
+    test!(
+        escape_all_quotes_bytes_invalid_utf8,
+        escape_all_quotes_bytes(&b"\xa1"[..]) == &b"\xa1"[..]
+    );
 }

--- a/src/unescape.rs
+++ b/src/unescape.rs
@@ -860,6 +860,15 @@ mod tests {
         include_str!("../tests/corpus/all-entities-expanded.txt");
     test_both!(all_entities, unescape(ALL_SOURCE) == ALL_EXPANDED);
 
+    test!(
+        invalid_utf8,
+        unescape_bytes_in(&b"\xa1"[..], Context::General) == &b"\xa1"[..]
+    );
+    test!(
+        attribute_invalid_utf8,
+        unescape_bytes_in(&b"\xa1"[..], Context::Attribute) == &b"\xa1"[..]
+    );
+
     #[test]
     fn correct_numeric_entity_euro() {
         match correct_numeric_entity(0x80) {


### PR DESCRIPTION
These just check that the `_bytes` functions actually can work on invalid UTF-8.