### PR TITLE
Add `clippy::missing_docs_in_private_items` lint

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,17 @@
-// Generates code from entities.json depending on enabled features.
-//
-// The canonical source is https://html.spec.whatwg.org/entities.json (see
-// https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references).
-//
-// The entities.json file looks like:
-//
-//     {
-//         "&AElig": { "codepoints": [198], "characters": "\u00C6" },
-//         . . .
-//     }
+//! Generates code from entities.json depending on enabled features.
+//!
+//! The canonical source is <https://html.spec.whatwg.org/entities.json> (see
+//! <https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references>).
+//!
+//! The entities.json file looks like:
+//!
+//!     {
+//!         "&AElig": { "codepoints": [198], "characters": "\u00C6" },
+//!         . . .
+//!     }
 
 #![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
+#![warn(clippy::pedantic, missing_docs, clippy::missing_docs_in_private_items)]
 #![allow(
     clippy::let_underscore_untyped,
     clippy::map_unwrap_or,
@@ -29,6 +29,9 @@ fn main() {
     generate_entities_rs(&entities);
 }
 
+/// Generate entities.rs file containing all valid HTML entities in a
+/// [`phf::Map`] along with a few useful constants. It also generates
+/// documentation with all entities in a table.
 #[cfg(feature = "entities")]
 fn generate_entities_rs(entities: &[(String, String)]) {
     use std::cmp::{max, min};
@@ -101,6 +104,9 @@ fn generate_entities_rs(entities: &[(String, String)]) {
         pub const ENTITY_MIN_LENGTH: usize = {min_len};").unwrap();
 }
 
+/// Generated matcher.rs file containing a function `entity_matcher()` that is
+/// basically just a giant nested tree of `match` expressions to check if the
+/// next bytes in an iterator are an HTML entity.
 #[cfg(feature = "unescape_fast")]
 fn generate_matcher_rs(entities: &[(String, String)]) {
     use std::env;
@@ -130,6 +136,7 @@ fn generate_matcher_rs(entities: &[(String, String)]) {
     writeln!(out).unwrap();
 }
 
+/// Load HTML entities as `vec![...("&gt;", ">")...]`.
 #[cfg(any(feature = "unescape_fast", feature = "entities"))]
 fn load_entities<P: AsRef<std::path::Path>>(path: P) -> Vec<(String, String)> {
     let input = std::fs::read(path.as_ref()).unwrap();

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,6 +1,8 @@
 use paste::paste;
 use std::borrow::Cow;
 
+/// Find a `u8` in a slice. You may specify as many bytes to search for as you
+/// want. If you are searching for 3 or fewer bytes, this will use [`memchr`].
 macro_rules! find_u8_body {
     ($slice:expr, $ch1:literal $(,)?) => {
         memchr::memchr($ch1, $slice)
@@ -16,6 +18,7 @@ macro_rules! find_u8_body {
     };
 }
 
+/// Generate string and byte string versions of an escape function.
 macro_rules! escape_fn {
     (
         $(#[$meta:meta])*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,17 +68,18 @@
 //! [benchmarks]: https://github.com/danielparks/htmlize#benchmarks
 
 #![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
+#![warn(clippy::pedantic, missing_docs, clippy::missing_docs_in_private_items)]
 #![allow(
     clippy::let_underscore_untyped,
     clippy::map_unwrap_or,
     clippy::module_name_repetitions
 )]
-#![warn(missing_docs)]
 
+/// Functions to escape raw text into HTML.
 mod escape;
 pub use escape::*;
 
+/// Functions to unescape HTML into raw text.
 #[cfg(any(feature = "unescape", feature = "unescape_fast"))]
 mod unescape;
 #[cfg(any(feature = "unescape", feature = "unescape_fast"))]

--- a/src/unescape.rs
+++ b/src/unescape.rs
@@ -35,8 +35,8 @@ pub enum Context {
     Attribute,
 }
 
-// Call the correct internal version of the unescape function (_fast or _slow).
-// See “_fast and _slow” heading in the comment at the top of this file.
+/// Call the correct internal version of the unescape function (_fast or _slow).
+/// See “_fast and _slow” heading in the comment at the top of this file.
 macro_rules! call_unescape {
     ($function:ident($($args:expr),+)) => {
         paste! {
@@ -155,12 +155,12 @@ pub fn unescape_bytes_in<'a, S: Into<Cow<'a, [u8]>>>(
     call_unescape!(unescape_bytes_in(escaped, context));
 }
 
-// Generate the _fast and _slow version of the unescape functions.
-//
-// See “_fast and _slow” heading in the comment at the top of this file.
-//
-// #[allow(dead_code)] is required to avoid false positive lints. Every
-// function is used in tests.
+/// Generate the _fast and _slow version of the unescape functions.
+///
+/// See “_fast and _slow” heading in the comment at the top of this file.
+///
+/// `#[allow(dead_code)]` is required to avoid false positive lints. Every
+/// function is used in tests.
 macro_rules! unescape_fns {
     ($vis:vis $suffix:ident) => {
         paste! {
@@ -336,6 +336,7 @@ fn match_entity_fast<'a>(
     }
 }
 
+/// A panic message we use repeatedly.
 const PEEK_MATCH_ERROR: &str = "iter.next() did not match previous peek(iter)";
 
 /// Match an entity at the beginning of `iter`. Either:
@@ -452,6 +453,7 @@ fn match_entity_slow<'a>(
     None
 }
 
+/// Match a numeric entity like `&#x20;` or `&#32;`.
 #[allow(clippy::from_str_radix_10)]
 fn match_numeric_entity(
     iter: &mut slice::Iter<u8>,
@@ -517,7 +519,9 @@ fn match_numeric_entity(
 /// the Specials block is [available as a PDF](https://www.unicode.org/charts/PDF/UFFF0.pdf).
 pub const REPLACEMENT_CHAR_BYTES: &[u8] = "\u{fffd}".as_bytes();
 
-// https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
+/// Calculate the expansion for a numeric entity (after parsing it).
+///
+/// See <https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state>
 #[allow(clippy::match_same_arms)]
 fn correct_numeric_entity(number: u32) -> Cow<'static, [u8]> {
     match number {
@@ -602,6 +606,8 @@ where
     false
 }
 
+/// Advance iterator while `predicate` matches (`next()` will return the first
+/// byte that doesn’t match) and return a slice of the bytes that didn’t match.
 #[inline]
 fn slice_while<'a, P>(
     iter: &mut slice::Iter<'a, u8>,
@@ -613,6 +619,8 @@ where
     slice_until(iter, move |c| !predicate(c))
 }
 
+/// Advance iterator until the byte _before_ `predicate` matches and return a
+/// slice of the bytes matched.
 #[inline]
 fn slice_until<'a, P>(iter: &mut slice::Iter<'a, u8>, predicate: P) -> &'a [u8]
 where


### PR DESCRIPTION
It’s generally a good idea to explain what things do, even if they’re not public.