### PR TITLE
Add `clippy::arithmetic_side_effects` restriction lint

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,12 @@
 //!     }
 
 #![forbid(unsafe_code)]
-#![warn(clippy::pedantic, missing_docs, clippy::missing_docs_in_private_items)]
+#![warn(
+    clippy::pedantic,
+    clippy::arithmetic_side_effects,
+    missing_docs,
+    clippy::missing_docs_in_private_items
+)]
 #![allow(
     clippy::let_underscore_untyped,
     clippy::map_unwrap_or,

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -70,15 +70,24 @@ macro_rules! escape_fn {
                 }
 
                 if let Some(i) = find_u8(raw) {
-                    let mut output: Vec<u8> = Vec::with_capacity(raw.len() * 2);
+                    let mut output: Vec<u8> = Vec::with_capacity(raw.len().saturating_mul(2));
                     output.extend_from_slice(&raw[..i]);
                     output.extend_from_slice(map_u8(raw[i]));
+
+                    // i is a valid index, so it can't be usize::MAX.
+                    debug_assert!(i < usize::MAX);
+                    #[allow(clippy::arithmetic_side_effects)]
                     let mut remainder = &raw[i+1..];
 
                     while let Some(i) = find_u8(remainder) {
                         output.extend_from_slice(&remainder[..i]);
                         output.extend_from_slice(map_u8(remainder[i]));
-                        remainder = &remainder[i+1..];
+
+                        // i is a valid index, so it can't be usize::MAX.
+                        debug_assert!(i < usize::MAX);
+                        #[allow(clippy::arithmetic_side_effects)]
+                        let n = i + 1; // Work around https://github.com/rust-lang/rust/issues/15701
+                        remainder = &remainder[n..];
                     }
 
                     output.extend_from_slice(&remainder);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,12 @@
 //! [benchmarks]: https://github.com/danielparks/htmlize#benchmarks
 
 #![forbid(unsafe_code)]
-#![warn(clippy::pedantic, missing_docs, clippy::missing_docs_in_private_items)]
+#![warn(
+    clippy::pedantic,
+    clippy::arithmetic_side_effects,
+    missing_docs,
+    clippy::missing_docs_in_private_items
+)]
 #![allow(
     clippy::let_underscore_untyped,
     clippy::map_unwrap_or,


### PR DESCRIPTION
This lint checks for potential under and overflow caused by arithmetic. I added `debug_assert!` checks and comments for each of the exceptions that I carved out.