### PR TITLE
Use cargo-lints to centrally configure lints

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -41,10 +41,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+          tool: cargo-lints
+      - run: cargo lints clippy --all-features --all-targets
 
   msrv:
     name: cargo msrv

--- a/benches/escape.rs
+++ b/benches/escape.rs
@@ -1,14 +1,6 @@
 //! Benchmark `escape` functions with [`criterion`].
 
-#![forbid(unsafe_code)]
-#![warn(clippy::nursery, clippy::pedantic)]
-#![allow(
-    clippy::let_underscore_untyped,
-    clippy::map_unwrap_or,
-    clippy::module_name_repetitions
-)]
-// Other restriction lints
-#![warn(clippy::arithmetic_side_effects)]
+#![allow(clippy::missing_docs_in_private_items, missing_docs)]
 
 use criterion::{
     criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,

--- a/benches/escape_iai.rs
+++ b/benches/escape_iai.rs
@@ -1,14 +1,6 @@
 //! Benchmark `escape` functions with [`iai`].
 
-#![forbid(unsafe_code)]
-#![warn(clippy::nursery, clippy::pedantic)]
-#![allow(
-    clippy::let_underscore_untyped,
-    clippy::map_unwrap_or,
-    clippy::module_name_repetitions
-)]
-// Other restriction lints
-#![warn(clippy::arithmetic_side_effects)]
+#![allow(clippy::missing_docs_in_private_items, missing_docs)]
 
 #[allow(clippy::wildcard_imports)]
 use htmlize::*;

--- a/benches/unescape.rs
+++ b/benches/unescape.rs
@@ -1,14 +1,6 @@
 //! Benchmark `unescape` functions with [`criterion`].
 
-#![forbid(unsafe_code)]
-#![warn(clippy::nursery, clippy::pedantic)]
-#![allow(
-    clippy::let_underscore_untyped,
-    clippy::map_unwrap_or,
-    clippy::module_name_repetitions
-)]
-// Other restriction lints
-#![warn(clippy::arithmetic_side_effects)]
+#![allow(clippy::missing_docs_in_private_items, missing_docs)]
 
 use criterion::{
     criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,

--- a/benches/unescape_iai.rs
+++ b/benches/unescape_iai.rs
@@ -1,14 +1,6 @@
 //! Benchmark `unescape` functions with [`iai`].
 
-#![forbid(unsafe_code)]
-#![warn(clippy::nursery, clippy::pedantic)]
-#![allow(
-    clippy::let_underscore_untyped,
-    clippy::map_unwrap_or,
-    clippy::module_name_repetitions
-)]
-// Other restriction lints
-#![warn(clippy::arithmetic_side_effects)]
+#![allow(clippy::missing_docs_in_private_items, missing_docs)]
 
 #[allow(clippy::wildcard_imports)]
 use htmlize::*;

--- a/build.rs
+++ b/build.rs
@@ -10,18 +10,6 @@
 //!         . . .
 //!     }
 
-#![forbid(unsafe_code)]
-#![warn(clippy::nursery, clippy::pedantic)]
-#![allow(
-    clippy::let_underscore_untyped,
-    clippy::map_unwrap_or,
-    clippy::module_name_repetitions
-)]
-// Require docs on everything
-#![warn(missing_docs, clippy::missing_docs_in_private_items)]
-// Other restriction lints
-#![warn(clippy::arithmetic_side_effects)]
-
 fn main() {
     #[cfg(any(feature = "unescape_fast", feature = "entities"))]
     let entities = load_entities("entities.json");

--- a/lints.toml
+++ b/lints.toml
@@ -1,0 +1,51 @@
+deny = [
+  "unsafe_code",
+]
+
+warn = [
+  "clippy::nursery",
+  "clippy::pedantic",
+
+  # Require docs
+  "missing_docs",
+  "clippy::missing_docs_in_private_items",
+
+  # Other restriction lints
+  "clippy::arithmetic_side_effects",
+  "clippy::as_underscore",
+  "clippy::assertions_on_result_states",
+  "clippy::dbg_macro",
+  "clippy::default_union_representation",
+  "clippy::empty_structs_with_brackets",
+  "clippy::filetype_is_file", # maybe?
+  "clippy::fn_to_numeric_cast_any",
+  "clippy::format_push_string", # maybe? alternative is fallible.
+  "clippy::get_unwrap",
+  "clippy::impl_trait_in_params",
+  "clippy::integer_division",
+  "clippy::lossy_float_literal",
+  "clippy::mem_forget",
+  "clippy::mixed_read_write_in_expression",
+  "clippy::multiple_inherent_impl",
+  "clippy::multiple_unsafe_ops_per_block",
+  "clippy::mutex_atomic",
+  "clippy::rc_buffer",
+  "clippy::rc_mutex",
+  "clippy::same_name_method",
+  "clippy::semicolon_inside_block",
+  "clippy::str_to_string",
+  "clippy::string_to_string",
+  "clippy::undocumented_unsafe_blocks",
+  "clippy::unnecessary_safety_doc",
+  "clippy::unnecessary_self_imports",
+  "clippy::unneeded_field_pattern",
+  "clippy::verbose_file_reads",
+]
+
+allow = [
+  # Pedantic exceptions
+  "clippy::let_underscore_untyped",
+  "clippy::manual_string_new",
+  "clippy::map_unwrap_or",
+  "clippy::module_name_repetitions",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,17 +67,9 @@
 //! [iai]: https://crates.io/crates/iai
 //! [benchmarks]: https://github.com/danielparks/htmlize#benchmarks
 
+// Most lint configuration is in lints.toml, but that isn’t supported by
+// cargo-geiger, and it only supports deny, not forbid.
 #![forbid(unsafe_code)]
-#![warn(clippy::nursery, clippy::pedantic)]
-#![allow(
-    clippy::let_underscore_untyped,
-    clippy::map_unwrap_or,
-    clippy::module_name_repetitions
-)]
-// Require docs on everything
-#![warn(missing_docs, clippy::missing_docs_in_private_items)]
-// Other restriction lints
-#![warn(clippy::arithmetic_side_effects)]
 
 /// Functions to escape raw text into HTML.
 mod escape;


### PR DESCRIPTION
Previously lints had to be configured at the top of every entry point in rust code — `lib.rs`, `build.rs`, and each benchmark file. This allows lints to be centrally configured in `lints.toml` and ensures they are applied to all targets.

This also updates the lint list to match my other projects. It includes a bunch more restriction lints.

To run lints:

    cargo lints clippy --all-targets --all-features

This requires [cargo-lints] to be installed.

[cargo-lints]: https://crates.io/crates/cargo-lints