### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - $default-branch
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: cargo build --tests
+      - run: cargo build --tests --all-features
       - run: cargo test --all-features
       - run: cargo test --features unescape
       - run: cargo test --features entities

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-msrv


### PR DESCRIPTION
- **PR Checks: fix workflow to run after merging a PR**
  Previously the job would only run when opening or updating a PR. This
  was unintentional, and a result of a misunderstanding of the
  `$default-branch` “macro”, which is only used in workflow _templates_.
  In actual workflows, it does nothing. This just changes to explicitly
  using the branch name `main`.
  
  It’s important that the job run after merge in order to update the
  cache. The cache that’s saved when the PR is opened or updated is
  [isolated to just that PR][isolation], whereas the cache on `main` can
  be accessed by future PRs.
  
  [isolation]: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

- **PR Checks: `cargo build --tests --all-features`.**
  

- **PR Checks: add caching for `cargo msrv verify`.**
  