### PR TITLE
Security: update indirect dependency rustix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ All notable changes to this project will be documented in this file.
 * Hide usage of [assert2] in doc examples to make them slightly clearer for
   users not familiar with it.
 
+### Security fixes
+
+* Upgrade indirect dependency [rustix] to fix a [security
+  vulnerability][GHSA-c827-hfw6-qwvm] in directory iterators. This does not
+  affect htmlize, since rustix is only used by development dependencies.
+
 [assert2]: https://crates.io/crates/assert2
+[rustix]: https://crates.io/crates/rustix
+[GHSA-c827-hfw6-qwvm]: https://github.com/advisories/GHSA-c827-hfw6-qwvm
 
 ## Release 1.0.3 (2023-07-09)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags",
  "errno",


### PR DESCRIPTION
Upgrade indirect dependency [rustix] to fix a [security vulnerability][GHSA-c827-hfw6-qwvm] in directory iterators. This does not affect htmlize, since rustix is only used by development dependencies.

[rustix]: https://crates.io/crates/rustix
[GHSA-c827-hfw6-qwvm]: https://github.com/advisories/GHSA-c827-hfw6-qwvm