### PR TITLE
Remove unneeded `use std::convert::TryInto`

### DIFF
--- a/benches/escape.rs
+++ b/benches/escape.rs
@@ -7,7 +7,6 @@ use criterion::{
 };
 #[allow(clippy::wildcard_imports)]
 use htmlize::*;
-use std::convert::TryInto;
 use std::time::Duration;
 
 mod util;

--- a/benches/unescape.rs
+++ b/benches/unescape.rs
@@ -7,7 +7,6 @@ use criterion::{
 };
 #[allow(clippy::wildcard_imports)]
 use htmlize::*;
-use std::convert::TryInto;
 use std::time::Duration;
 
 #[macro_use]


### PR DESCRIPTION
It is imported by the Rust 2021 prelude.