### PR TITLE
Add Unicode-3.0 to allowed licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,7 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "MIT",
+  "Unicode-3.0",
   "Unicode-DFS-2016",
   "Unlicense",
   "Zlib",


### PR DESCRIPTION
The [license] looks to be a simple, BSD-style license.

[license]: https://opensource.org/license/unicode-license-v3