### PR TITLE
Switch from `paste` to `pastey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 1.0.6 (2025-04-26)
 
 * Switch dependency from [paste], which is no longer maintained, to a new fork,
   [pastey], which is.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+* Switch dependency from [paste], which is no longer maintained, to a new fork,
+  [pastey], which is.
+
+[paste]: https://github.com/dtolnay/paste
+[pastey]: https://github.com/as1100k/pastey
+
 ## Release 1.0.5 (2024-03-14)
 
 * Exclude more files from final package to significantly reduce package size.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,9 +240,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "htmlize"
@@ -253,7 +253,7 @@ dependencies = [
  "iai",
  "matchgen",
  "memchr",
- "paste",
+ "pastey",
  "phf",
  "phf_codegen",
  "serde_json",
@@ -383,10 +383,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
-name = "paste"
-version = "1.0.12"
+name = "pastey"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "b3a8cb46bdc156b1c90460339ae6bfd45ba0394e5effbaa640badb4987fdc261"
 
 [[package]]
 name = "phf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "htmlize"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "assert2",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htmlize"
-version = "1.0.5"
+version = "1.0.6"
 authors = ["Daniel Parks <oss-htmlize@demonhorse.org>"]
 description = "Encode and decode HTML entities in UTF-8 according to the standard"
 homepage = "https://github.com/danielparks/htmlize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = { version = "1.0", optional = true }
 
 [dependencies]
 memchr = "2.5.0"
-paste = "1.0.11"
+pastey = "0.1.0"
 phf = { version = "0.11.1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -189,20 +189,20 @@ additional terms or conditions.
 
 [docs.rs]: https://docs.rs/htmlize/latest/htmlize/
 [crates.io]: https://crates.io/crates/htmlize
-[`escape_text()`]: https://docs.rs/htmlize/1.0.5/htmlize/fn.escape_text.html
-[`escape_text_bytes()`]: https://docs.rs/htmlize/1.0.5/htmlize/fn.escape_text_bytes.html
-[`escape_attribute()`]: https://docs.rs/htmlize/1.0.5/htmlize/fn.escape_attribute.html
-[`escape_attribute_bytes()`]: https://docs.rs/htmlize/1.0.5/htmlize/fn.escape_attribute_bytes.html
-[`escape_all_quotes()`]: https://docs.rs/htmlize/1.0.5/htmlize/fn.escape_all_quotes.html
-[`escape_all_quotes_bytes()`]: https://docs.rs/htmlize/1.0.5/htmlize/fn.escape_all_quotes_bytes.html
-[`unescape()`]: https://docs.rs/htmlize/1.0.5/htmlize/fn.unescape.html
-[`unescape_attribute()`]: https://docs.rs/htmlize/1.0.5/htmlize/fn.unescape_attribute.html
-[`unescape_in()`]: https://docs.rs/htmlize/1.0.5/htmlize/fn.unescape_in.html
-[`unescape_bytes_in()`]: https://docs.rs/htmlize/1.0.5/htmlize/fn.unescape_bytes_in.html
+[`escape_text()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_text.html
+[`escape_text_bytes()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_text_bytes.html
+[`escape_attribute()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_attribute.html
+[`escape_attribute_bytes()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_attribute_bytes.html
+[`escape_all_quotes()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_all_quotes.html
+[`escape_all_quotes_bytes()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_all_quotes_bytes.html
+[`unescape()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.unescape.html
+[`unescape_attribute()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.unescape_attribute.html
+[`unescape_in()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.unescape_in.html
+[`unescape_bytes_in()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.unescape_bytes_in.html
 [`Cow`]: https://doc.rust-lang.org/std/borrow/enum.Cow.html
 [official WHATWG algorithm]: https://html.spec.whatwg.org/multipage/parsing.html#character-reference-state
 [phf]: https://crates.io/crates/phf
-[features]: https://docs.rs/htmlize/1.0.5/htmlize/index.html#features
+[features]: https://docs.rs/htmlize/1.0.6/htmlize/index.html#features
 [iai]: https://crates.io/crates/iai
 [criterion]: https://crates.io/crates/criterion
 [`cargo criterion`]: https://crates.io/crates/cargo-criterion

--- a/benches/escape_iai.rs
+++ b/benches/escape_iai.rs
@@ -5,7 +5,7 @@
 #[allow(clippy::wildcard_imports)]
 use htmlize::*;
 use iai::black_box;
-use paste::paste;
+use pastey::paste;
 use std::borrow::Cow;
 
 mod util;

--- a/benches/unescape_iai.rs
+++ b/benches/unescape_iai.rs
@@ -5,7 +5,7 @@
 #[allow(clippy::wildcard_imports)]
 use htmlize::*;
 use iai::black_box;
-use paste::paste;
+use pastey::paste;
 use std::borrow::Cow;
 
 mod util;

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,6 +1,6 @@
 //! # Functions to escape raw text into HTML
 
-use paste::paste;
+use pastey::paste;
 use std::borrow::Cow;
 
 /// Find a `u8` in a slice. You may specify as many bytes to search for as you
@@ -231,7 +231,7 @@ escape_fn! {
 mod tests {
     use super::*;
     use assert2::assert;
-    use paste::paste;
+    use pastey::paste;
 
     macro_rules! test {
         ($name:ident, $($test:tt)+) => {

--- a/src/unescape.rs
+++ b/src/unescape.rs
@@ -17,7 +17,7 @@
 //! in the public API, but it still builds the slow versions so that all
 //! functions can be tested.
 
-use paste::paste;
+use pastey::paste;
 use std::borrow::Cow;
 use std::char;
 use std::num::IntErrorKind;
@@ -729,7 +729,7 @@ where
 mod tests {
     use super::*;
     use assert2::assert;
-    use paste::paste;
+    use pastey::paste;
 
     // Test fast and slow versions of a function.
     macro_rules! test {

--- a/src/unescape.rs
+++ b/src/unescape.rs
@@ -77,7 +77,7 @@ pub fn unescape_attribute<'a, S: Into<Cow<'a, str>>>(
 /// `context` may be:
 ///
 ///   * `Context::General`: use the rules for text outside of an attribute.
-///      This is usually what you want.
+///     This is usually what you want.
 ///   * `Context::Attribute`: use the rules for attribute values.
 ///
 /// This uses the [algorithm described] in the WHATWG spec. In attributes,
@@ -118,7 +118,7 @@ pub fn unescape_in<'a, S: Into<Cow<'a, str>>>(
 /// `context` may be:
 ///
 ///   * `Context::General`: use the rules for text outside of an attribute.
-///      This is usually what you want.
+///     This is usually what you want.
 ///   * `Context::Attribute`: use the rules for attribute values.
 ///
 /// This uses the [algorithm described] in the WHATWG spec. In attributes,


### PR DESCRIPTION
[`paste`] is [no longer maintained.][alternative]

* [x] Review [`pastey`] code.

[`paste`]: https://github.com/dtolnay/paste
[alternative]: https://users.rust-lang.org/t/paste-alternatives/126787/7
[`pastey`]: https://github.com/as1100k/pastey