### PR TITLE
GitHub PR checks: update actions and match template

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -8,36 +8,12 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: cargo test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: cargo build --tests --all-features
-      - run: cargo test --all-features
-      - run: cargo test --features unescape
-      - run: cargo test --features entities
-      - run: cargo test
-
-  fmt:
-    name: cargo fmt
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: rustfmt
-      - uses: actions-rust-lang/rustfmt@v1
-
   clippy:
     name: cargo clippy
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
@@ -52,17 +28,43 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: "1.85.0"
+
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - uses: actions-rust-lang/rustfmt@v1
 
   msrv:
     name: cargo msrv
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-msrv
       - run: cargo msrv verify
+
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo build --tests --all-features
+      - run: cargo test --all-features
+      - run: cargo test --features unescape
+      - run: cargo test --features entities
+      - run: cargo test


### PR DESCRIPTION
Update file to more closely match my standard Rust project template. This also
configures `cargo deny` to use a recent version of `cargo` that supports the
latest Rust edition (2024).
