### PR TITLE
Upgrade phf and phf_codegen to 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,18 +396,18 @@ checksum = "b3a8cb46bdc156b1c90460339ae6bfd45ba0394e5effbaa640badb4987fdc261"
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -409,19 +415,19 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -471,21 +477,6 @@ checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
@@ -607,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,14 @@ _unescape_either = []
 
 [build-dependencies]
 matchgen = { version = "0.4.0", optional = true }
-phf = { version = "0.11.1", default-features = false, optional = true }
-phf_codegen = { version = "0.11.1", optional = true }
+phf = { version = "0.13.1", default-features = false, optional = true }
+phf_codegen = { version = "0.13.1", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [dependencies]
 memchr = "2.5.0"
 pastey = "0.1.0"
-phf = { version = "0.11.1", default-features = false, optional = true }
+phf = { version = "0.13.1", default-features = false, optional = true }
 
 [dev-dependencies]
 assert2 = "0.3.7"

--- a/build.rs
+++ b/build.rs
@@ -56,7 +56,7 @@ fn generate_entities_rs(entities: &[(String, String)]) {
     let mut min_len: usize = usize::MAX;
     let mut bare_max_len: usize = 0;
     for (name, glyph) in entities {
-        map_builder.entry(name.as_bytes(), &format!("&{:?}", glyph.as_bytes()));
+        map_builder.entry(name.as_bytes(), format!("&{:?}", glyph.as_bytes()));
         max_len = max(max_len, name.len());
         min_len = min(min_len, name.len());
         if !name.ends_with(';') {


### PR DESCRIPTION
[RUSTSEC-2026-0097](osv.dev/vulnerability/RUSTSEC-2026-0097) points out that `rand 0.8.5` is potentially unsound. No fix has been backported to `rand 0.8`, so I imagine most projects want to move off of `rand 0.8` completely. This PR upgrades the dependencies of `htmlize` which transitively pulls in rand 0.8.5.

I've ran the tests locally, and they seem fine. Let me know if anything else needs to be done :)