### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 1.1.0 (2026-04-13)
 
 * Major performance improvements when unescaping text in many cases (for both
   the `unescape` and `unescape_fast` features).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ All notable changes to this project will be documented in this file.
 * Clarify examples in documentation and README.
 * Fix a few spelling mistakes in documentation.
 
+### Security
+
+* [RUSTSEC-2026-0097]: the [rand] crate was unsound in certain circumstances.
+  Htmlize depends on [rand] via [phf] and couldn’t trigger the unsoundness on
+  its own. Thanks to [MarkusPettersson98] for the [PR][#124]!
+
+[RUSTSEC-2026-0097]: https://rustsec.org/advisories/RUSTSEC-2026-0097
+[rand]: https://crates.io/crates/rand
+[phf]: https://crates.io/crates/phf
+[MarkusPettersson98]: https://github.com/MarkusPettersson98
+[#124]: https://github.com/danielparks/htmlize/pull/124
+
 ## Release 1.0.6 (2025-04-26)
 
 * Switch dependency from [paste], which is no longer maintained, to a new fork,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "htmlize"
-version = "1.0.6"
+version = "1.1.0"
 dependencies = [
  "assert2",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htmlize"
-version = "1.0.6"
+version = "1.1.0"
 authors = ["Daniel Parks <oss-htmlize@demonhorse.org>"]
 description = "Correctly encode and decode HTML entities in UTF-8"
 homepage = "https://github.com/danielparks/htmlize"

--- a/README.md
+++ b/README.md
@@ -217,20 +217,20 @@ additional terms or conditions.
 
 [docs.rs]: https://docs.rs/htmlize/latest/htmlize/
 [crates.io]: https://crates.io/crates/htmlize
-[`escape_text()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_text.html
-[`escape_text_bytes()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_text_bytes.html
-[`escape_attribute()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_attribute.html
-[`escape_attribute_bytes()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_attribute_bytes.html
-[`escape_all_quotes()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_all_quotes.html
-[`escape_all_quotes_bytes()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.escape_all_quotes_bytes.html
-[`unescape()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.unescape.html
-[`unescape_attribute()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.unescape_attribute.html
-[`unescape_in()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.unescape_in.html
-[`unescape_bytes_in()`]: https://docs.rs/htmlize/1.0.6/htmlize/fn.unescape_bytes_in.html
+[`escape_text()`]: https://docs.rs/htmlize/1.1.0/htmlize/fn.escape_text.html
+[`escape_text_bytes()`]: https://docs.rs/htmlize/1.1.0/htmlize/fn.escape_text_bytes.html
+[`escape_attribute()`]: https://docs.rs/htmlize/1.1.0/htmlize/fn.escape_attribute.html
+[`escape_attribute_bytes()`]: https://docs.rs/htmlize/1.1.0/htmlize/fn.escape_attribute_bytes.html
+[`escape_all_quotes()`]: https://docs.rs/htmlize/1.1.0/htmlize/fn.escape_all_quotes.html
+[`escape_all_quotes_bytes()`]: https://docs.rs/htmlize/1.1.0/htmlize/fn.escape_all_quotes_bytes.html
+[`unescape()`]: https://docs.rs/htmlize/1.1.0/htmlize/fn.unescape.html
+[`unescape_attribute()`]: https://docs.rs/htmlize/1.1.0/htmlize/fn.unescape_attribute.html
+[`unescape_in()`]: https://docs.rs/htmlize/1.1.0/htmlize/fn.unescape_in.html
+[`unescape_bytes_in()`]: https://docs.rs/htmlize/1.1.0/htmlize/fn.unescape_bytes_in.html
 [`Cow`]: https://doc.rust-lang.org/std/borrow/enum.Cow.html
 [official WHATWG spec]: https://html.spec.whatwg.org/multipage/parsing.html#character-reference-state
 [phf]: https://crates.io/crates/phf
-[features]: https://docs.rs/htmlize/1.0.6/htmlize/index.html#features
+[features]: https://docs.rs/htmlize/1.1.0/htmlize/index.html#features
 [iai]: https://crates.io/crates/iai
 [criterion]: https://crates.io/crates/criterion
 [`cargo criterion`]: https://crates.io/crates/cargo-criterion

--- a/src/unescape/mod.rs
+++ b/src/unescape/mod.rs
@@ -233,3 +233,5 @@ pub mod internal;
 
 #[cfg(not(all(feature = "bench", not(doc))))]
 mod internal;
+
+pub use internal::REPLACEMENT_CHAR_BYTES;


### PR DESCRIPTION
- **CHANGELOG.md: add security note about recent PR.**
  

- **Make `REPLACEMENT_CHAR_BYTES` public again.**
  

- **Release 1.1.0**
  * Major performance improvements when unescaping text in many cases (for both
    the `unescape` and `unescape_fast` features).
  * Major improvements in build time for the `unescape_fast` features (went from
    8 seconds to 3 seconds on my laptop).
  * Add `BARE_ENTITY_MAX_LENGTH` constant that contains the length of the longest
    entity without a semicolon (enabled with feature `entities`).
  * Clarify examples in documentation and README.
  * Fix a few spelling mistakes in documentation.
  
  ### Security
  
  * [RUSTSEC-2026-0097]: the [rand] crate was unsound in certain circumstances.
    Htmlize depends on [rand] via [phf] and couldn’t trigger the unsoundness on
    its own. Thanks to [MarkusPettersson98] for the [PR][#124]!
  
  [RUSTSEC-2026-0097]: https://rustsec.org/advisories/RUSTSEC-2026-0097
  [rand]: https://crates.io/crates/rand
  [phf]: https://crates.io/crates/phf
  [MarkusPettersson98]: https://github.com/MarkusPettersson98
  [#124]: https://github.com/danielparks/htmlize/pull/124
  