### PR TITLE
Updates to CI to match matchgen

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -7,76 +7,82 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CLICOLOR: 1
 
+# These would more naturally be separate jobs, but GitHub actions “bills” each
+# job separately and rounds up to the next minute, so four 10 second jobs “cost”
+# my account 4 action minutes.
 jobs:
-  clippy:
-    name: cargo clippy
+  checks:
+    name: Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write # SARIF reporting for zizmor
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
+          toolchain: stable
           components: clippy
-      - run: cargo clippy --all-features --all-targets
-      - name: check doc lints
-        env:
-          RUSTDOCFLAGS: --document-private-items -Dwarnings
-        run: cargo doc --no-deps --all-features
 
-  deny:
-    name: cargo deny
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
-        with:
-          rust-version: "1.85.0"
-
-  fmt:
-    name: cargo fmt
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
+          toolchain: nightly
           components: rustfmt
-      - uses: actions-rust-lang/rustfmt@4066006ec54a31931b9b1fddfd38f2fdf2d27143 # v1.1.2
 
-  msrv:
-    name: cargo msrv
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
       - uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
         with:
           tool: cargo-msrv
-      - run: cargo msrv verify
 
-  test:
-    name: cargo test
-    runs-on: ubuntu-latest
+      - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
+        if: ${{ !cancelled() }}
 
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-      - run: cargo build --tests --all-features
-      - run: cargo test --all-features
-      - run: cargo test --features unescape
-      - run: cargo test --features unescape_fast
-      - run: cargo test --features entities
-      - run: cargo test
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        if: ${{ !cancelled() }}
+        with:
+          persona: pedantic
 
-  typos:
-    name: typos
-    runs-on: ubuntu-latest
+      - uses: actions-rust-lang/rustfmt@4066006ec54a31931b9b1fddfd38f2fdf2d27143 # v1.1.2
+        if: ${{ !cancelled() }}
 
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: crate-ci/typos@f8a58b6b53f2279f71eb605f03a4ae4d10608f45 # v1.47.0
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        if: ${{ !cancelled() }}
+        with:
+          rust-version: "1.85.0"
+
+      - name: cargo clippy
+        if: ${{ !cancelled() }}
+        run: cargo +stable clippy --all-features --all-targets
+
+      - name: cargo doc lints
+        if: ${{ !cancelled() }}
+        env:
+          RUSTDOCFLAGS: --document-private-items -Dwarnings
+        run: cargo +stable doc --no-deps --all-features
+
+      - name: cargo msrv
+        if: ${{ !cancelled() }}
+        run: cargo msrv verify
+
+      - name: cargo build
+        id: cargo_build
+        if: ${{ !cancelled() }}
+        run: cargo +stable build --tests --all-features
+
+      - name: cargo test
+        if: ${{ !cancelled() && steps.cargo_build.outcome == 'success' }}
+        run: cargo +stable test --all-features

--- a/.github/workflows/prek-auto-update.yaml
+++ b/.github/workflows/prek-auto-update.yaml
@@ -7,8 +7,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   prek-auto-update:
+    name: prek auto-update
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,16 @@
 # Mostly copied from https://github.com/taiki-e/cargo-hack/blob/main/.github/workflows/release.yml
 name: Release
 
-permissions:
-  contents: read
-
 on:
   push:
     tags:
       - v*.*.*
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_INCREMENTAL: 0
@@ -21,9 +24,11 @@ env:
 jobs:
   create-release:
     if: github.repository_owner == 'danielparks'
+    name: Create
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
-      contents: write
+      contents: write # To create release
     steps:
       - uses: danielparks/github-actions/create-release@2f6c98c73f0a8130d737500b59a0fddf749b484d # v1.1.1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,13 @@ repos:
       - id: typos
         args: []
         exclude: "target/"
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+      - id: zizmor
+        args:
+          - "--no-progress" # https://github.com/zizmorcore/zizmor/issues/582
+          - "--persona=pedantic"
   - repo: local
     hooks:
       - id: cargo clippy

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,6 @@ max_width = 80
 newline_style = "Unix"
 struct_lit_width = 60
 use_field_init_shorthand = true
+
+unstable_features = true
+wrap_comments = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 //! assert!(escape_attribute("ab & < > \" '") == "ab &amp; &lt; &gt; &quot; '");
 //! assert!(escape_text("ab & < > \" '") == "ab &amp; &lt; &gt; \" '");
 //! ```
-//!
 #![cfg_attr(
     any(feature = "unescape", feature = "unescape_fast"),
     doc = r#"

--- a/src/unescape/internal.rs
+++ b/src/unescape/internal.rs
@@ -443,32 +443,45 @@ fn correct_numeric_entity(number: u32) -> Cow<'static, [u8]> {
 
         // control-character-reference parse error exceptions:
         0x80 => "\u{20AC}".as_bytes().into(), // EURO SIGN (€)
-        0x82 => "\u{201A}".as_bytes().into(), // SINGLE LOW-9 QUOTATION MARK (‚)
-        0x83 => "\u{0192}".as_bytes().into(), // LATIN SMALL LETTER F WITH HOOK (ƒ)
-        0x84 => "\u{201E}".as_bytes().into(), // DOUBLE LOW-9 QUOTATION MARK („)
+        0x82 => "\u{201A}".as_bytes().into(), /* SINGLE LOW-9 QUOTATION MARK
+                                                * (‚) */
+        0x83 => "\u{0192}".as_bytes().into(), /* LATIN SMALL LETTER F WITH
+                                                * HOOK (ƒ) */
+        0x84 => "\u{201E}".as_bytes().into(), /* DOUBLE LOW-9 QUOTATION MARK
+                                                * („) */
         0x85 => "\u{2026}".as_bytes().into(), // HORIZONTAL ELLIPSIS (…)
         0x86 => "\u{2020}".as_bytes().into(), // DAGGER (†)
         0x87 => "\u{2021}".as_bytes().into(), // DOUBLE DAGGER (‡)
-        0x88 => "\u{02C6}".as_bytes().into(), // MODIFIER LETTER CIRCUMFLEX ACCENT (ˆ)
+        0x88 => "\u{02C6}".as_bytes().into(), /* MODIFIER LETTER CIRCUMFLEX
+                                                * ACCENT (ˆ) */
         0x89 => "\u{2030}".as_bytes().into(), // PER MILLE SIGN (‰)
-        0x8A => "\u{0160}".as_bytes().into(), // LATIN CAPITAL LETTER S WITH CARON (Š)
-        0x8B => "\u{2039}".as_bytes().into(), // SINGLE LEFT-POINTING ANGLE QUOTATION MARK (‹)
+        0x8A => "\u{0160}".as_bytes().into(), /* LATIN CAPITAL LETTER S WITH
+                                                * CARON (Š) */
+        0x8B => "\u{2039}".as_bytes().into(), /* SINGLE LEFT-POINTING ANGLE
+                                                * QUOTATION MARK (‹) */
         0x8C => "\u{0152}".as_bytes().into(), // LATIN CAPITAL LIGATURE OE (Œ)
-        0x8E => "\u{017D}".as_bytes().into(), // LATIN CAPITAL LETTER Z WITH CARON (Ž)
+        0x8E => "\u{017D}".as_bytes().into(), /* LATIN CAPITAL LETTER Z WITH
+                                                * CARON (Ž) */
         0x91 => "\u{2018}".as_bytes().into(), // LEFT SINGLE QUOTATION MARK (‘)
-        0x92 => "\u{2019}".as_bytes().into(), // RIGHT SINGLE QUOTATION MARK (’)
+        0x92 => "\u{2019}".as_bytes().into(), /* RIGHT SINGLE QUOTATION MARK
+                                                * (’) */
         0x93 => "\u{201C}".as_bytes().into(), // LEFT DOUBLE QUOTATION MARK (“)
-        0x94 => "\u{201D}".as_bytes().into(), // RIGHT DOUBLE QUOTATION MARK (”)
+        0x94 => "\u{201D}".as_bytes().into(), /* RIGHT DOUBLE QUOTATION MARK
+                                                * (”) */
         0x95 => "\u{2022}".as_bytes().into(), // BULLET (•)
         0x96 => "\u{2013}".as_bytes().into(), // EN DASH (–)
         0x97 => "\u{2014}".as_bytes().into(), // EM DASH (—)
         0x98 => "\u{02DC}".as_bytes().into(), // SMALL TILDE (˜)
         0x99 => "\u{2122}".as_bytes().into(), // TRADE MARK SIGN (™)
-        0x9A => "\u{0161}".as_bytes().into(), // LATIN SMALL LETTER S WITH CARON (š)
-        0x9B => "\u{203A}".as_bytes().into(), // SINGLE RIGHT-POINTING ANGLE QUOTATION MARK (›)
+        0x9A => "\u{0161}".as_bytes().into(), /* LATIN SMALL LETTER S WITH
+                                                * CARON (š) */
+        0x9B => "\u{203A}".as_bytes().into(), /* SINGLE RIGHT-POINTING ANGLE
+                                                * QUOTATION MARK (›) */
         0x9C => "\u{0153}".as_bytes().into(), // LATIN SMALL LIGATURE OE (œ)
-        0x9E => "\u{017E}".as_bytes().into(), // LATIN SMALL LETTER Z WITH CARON (ž)
-        0x9F => "\u{0178}".as_bytes().into(), // LATIN CAPITAL LETTER Y WITH DIAERESIS (Ÿ)
+        0x9E => "\u{017E}".as_bytes().into(), /* LATIN SMALL LETTER Z WITH
+                                                * CARON (ž) */
+        0x9F => "\u{0178}".as_bytes().into(), /* LATIN CAPITAL LETTER Y WITH
+                                                * DIAERESIS (Ÿ) */
 
         // A few parse errors and other cases are handled by the catch-all.
         //

--- a/src/unescape/mod.rs
+++ b/src/unescape/mod.rs
@@ -13,8 +13,8 @@
 //! <https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references>
 //!
 //! Entities do not always require a trailing semicolon, though the exact rules
-//! depend on whether the entity appears in an attribute value or somewhere else.
-//! See [`unescape_in()`] for more information.
+//! depend on whether the entity appears in an attribute value or somewhere
+//! else. See [`unescape_in()`] for more information.
 //!
 //! Some entities are prefixes for multiple other entities. For example:
 //!   &times &times; &timesb; &timesbar; &timesd;
@@ -95,8 +95,8 @@ pub fn unescape_attribute<'a, S: Into<Cow<'a, str>>>(
 ///
 /// `context` may be:
 ///
-///   * `Context::General`: use the rules for text outside of an attribute.
-///     This is usually what you want.
+///   * `Context::General`: use the rules for text outside of an attribute. This
+///     is usually what you want.
 ///   * `Context::Attribute`: use the rules for attribute values.
 ///
 /// This uses the [algorithm described] in the WHATWG spec. In attributes,
@@ -163,8 +163,8 @@ pub fn unescape_in<'a, S: Into<Cow<'a, str>>>(
 ///
 /// `context` may be:
 ///
-///   * `Context::General`: use the rules for text outside of an attribute.
-///     This is usually what you want.
+///   * `Context::General`: use the rules for text outside of an attribute. This
+///     is usually what you want.
 ///   * `Context::Attribute`: use the rules for attribute values.
 ///
 /// This uses the [algorithm described] in the WHATWG spec. In attributes,


### PR DESCRIPTION
- **`cargo fmt`: enable unstable features to wrap comments.**
  

- **GitHub workflows: update to match matchgen**
  Also adds zizmor checks.
  