### PR TITLE
`cargo deny`: ignore unsound crate only used in benchmarks

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,9 @@
+[advisories]
+ignore = [
+  # crossbeam-epoch unsound (only used for benchmarks):
+  "RUSTSEC-2026-0204",
+]
+
 [graph]
 all-features = true
 


### PR DESCRIPTION
RUSTSEC-2026-0204 in crossbeam-epoch.
